### PR TITLE
Warning: Calling bottle :unneeded is deprecated!

### DIFF
--- a/config-bob.rb
+++ b/config-bob.rb
@@ -3,7 +3,6 @@ class ConfigBob < Formula
   desc "CLI utility to generate secure configurations"
   homepage "https://github.com/foomo/config-bob"
   version "0.6.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/foomo/config-bob/releases/download/0.6.2/config-bob_0.6.2_darwin_amd64.tar.gz"


### PR DESCRIPTION
```
$ brew install config-bob
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the foomo/config-bob tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/foomo/homebrew-config-bob/config-bob.rb:6

==> Downloading https://github.com/foomo/config-bob/releases/download/0.6.2/config-bob_0.6.2_darwin_amd64.tar.gz
==> Downloading from ....
######################################################################## 100.0%
==> Installing config-bob from foomo/config-bob
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the foomo/config-bob tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/foomo/homebrew-config-bob/config-bob.rb:6
```

I've removed it, not sure if correct.